### PR TITLE
ci(workflow): fix test verification for tool cache and allow manual runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -65,11 +66,12 @@ jobs:
     name: GitHub Actions Test
     runs-on: ubuntu-latest
     needs: test-typescript
-    # Only run when dist or workflow has been changed and disable on PR without write permissions
+    # Run on manual dispatch, or when dist or workflow has been changed on a PR with write permissions
     if: |
-      (needs.test-typescript.outputs.dist == 'true' || needs.test-typescript.outputs.ci == 'true') && 
-      github.event.pull_request.head.repo.full_name == github.repository && 
-      github.actor != 'dependabot[bot]'
+      github.event_name == 'workflow_dispatch' ||
+      ((needs.test-typescript.outputs.dist == 'true' || needs.test-typescript.outputs.ci == 'true') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]')
 
     steps:
       - name: Checkout
@@ -103,7 +105,7 @@ jobs:
         id: verify-results
         # BaiduPCS-Go has been logged in through the action above
         run: |
-          BAIDUPCS_GO_EXECUTABLE=$(find ./baidupcs -name BaiduPCS-Go)
+          BAIDUPCS_GO_EXECUTABLE=$(find "$RUNNER_TOOL_CACHE/BaiduPCS-Go" -type f -name BaiduPCS-Go)
           DATE=$(TZ=Asia/Shanghai date +%F)
           LS_OUTPUT=$($BAIDUPCS_GO_EXECUTABLE ls /baidu-netdisk-upload-action-test/)
           grep --quiet "$DATE.*upload-1.txt" <<< "$LS_OUTPUT"


### PR DESCRIPTION
## Why

The integration test (`test-action` job) never ran for the `@actions/tool-cache` migration (e14a6e8): it was committed directly to main, and the job's `if` condition only matches `pull_request` events. Worse, its "Verify Results" step would have failed anyway — it looks for the BaiduPCS-Go binary in `./baidupcs`, the extraction directory that the old hand-rolled download code used and the tool-cache migration removed.

## What

- Locate the binary in the runner tool cache (`$RUNNER_TOOL_CACHE/BaiduPCS-Go`) in the verify step, where `@actions/tool-cache` now caches it.
- Add a `workflow_dispatch` trigger and let it bypass the PR-only condition on `test-action`, so the integration test can be fired manually from the Actions tab in the future.

## Test plan

This PR itself triggers the integration test (the `ci.yml` change trips the paths filter), exercising the tool-cache code already on main end-to-end: download → cache → login → upload → verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)